### PR TITLE
Fix eating particles colliding with amenity model

### DIFF
--- a/Assets/Amenities/Food/Lvl 1/Prefabs/MediumFoodLvl1.prefab
+++ b/Assets/Amenities/Food/Lvl 1/Prefabs/MediumFoodLvl1.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 7903785928979427881}
   - component: {fileID: 662623732679593631}
   - component: {fileID: 4375938332252148990}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -117,7 +117,7 @@ GameObject:
   - component: {fileID: 6549582822261425750}
   - component: {fileID: 8788092267770722556}
   - component: {fileID: 5556254382837870127}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -222,7 +222,7 @@ GameObject:
   - component: {fileID: 960340405999617401}
   - component: {fileID: 1211609523985714573}
   - component: {fileID: 4675317760209920467}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (18)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -327,7 +327,7 @@ GameObject:
   - component: {fileID: 3775127465106295733}
   - component: {fileID: 8913367682218179139}
   - component: {fileID: 4059083386151174281}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -432,7 +432,7 @@ GameObject:
   - component: {fileID: 5650505648042168618}
   - component: {fileID: 6373209016071572387}
   - component: {fileID: 4734713814257918269}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (9)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -537,7 +537,7 @@ GameObject:
   - component: {fileID: 5411678063188319089}
   - component: {fileID: 3750791751275644653}
   - component: {fileID: 3703147843338992345}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -642,7 +642,7 @@ GameObject:
   - component: {fileID: 926007352576749433}
   - component: {fileID: 6815506435426456721}
   - component: {fileID: 7914531293975133667}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -747,7 +747,7 @@ GameObject:
   - component: {fileID: 2150663582712497701}
   - component: {fileID: 7567248591897976991}
   - component: {fileID: 1130010947092997766}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -856,7 +856,7 @@ GameObject:
   - component: {fileID: 3374377255919950127}
   - component: {fileID: 4229694274123343336}
   - component: {fileID: 6232564146642653295}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: MediumFoodLvl1
   m_TagString: Amenity
   m_Icon: {fileID: 0}
@@ -1045,7 +1045,7 @@ GameObject:
   - component: {fileID: 7389631920889278948}
   - component: {fileID: 2817750745217038900}
   - component: {fileID: 2718491884916564405}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1150,7 +1150,7 @@ GameObject:
   - component: {fileID: 7536267868618081945}
   - component: {fileID: 2969754306171399454}
   - component: {fileID: 4637254330381160354}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (20)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1252,7 +1252,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6313211946262004246}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Yuzus
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1305,7 +1305,7 @@ GameObject:
   - component: {fileID: 4519032392633870299}
   - component: {fileID: 2537501999356098959}
   - component: {fileID: 4641032469321496472}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1410,7 +1410,7 @@ GameObject:
   - component: {fileID: 2880808360269745531}
   - component: {fileID: 171209447200111380}
   - component: {fileID: 4105603468614233003}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1515,7 +1515,7 @@ GameObject:
   - component: {fileID: 9071143962382027672}
   - component: {fileID: 8768017928514680228}
   - component: {fileID: 4157652060789376800}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1620,7 +1620,7 @@ GameObject:
   - component: {fileID: 6629633737536139778}
   - component: {fileID: 8091924280176066653}
   - component: {fileID: 6382293466848450149}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1725,7 +1725,7 @@ GameObject:
   - component: {fileID: 3492270848359239154}
   - component: {fileID: 4497491256464848726}
   - component: {fileID: 1923790630638136283}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1830,7 +1830,7 @@ GameObject:
   - component: {fileID: 2395624408620892520}
   - component: {fileID: 4270039462352035195}
   - component: {fileID: 2607953471776197618}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1935,7 +1935,7 @@ GameObject:
   - component: {fileID: 3503826484348798167}
   - component: {fileID: 6444599838209829802}
   - component: {fileID: 6639877445783942132}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2040,7 +2040,7 @@ GameObject:
   - component: {fileID: 8381515115542734842}
   - component: {fileID: 1726168687112916609}
   - component: {fileID: 366352368710581990}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (19)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2145,7 +2145,7 @@ GameObject:
   - component: {fileID: 4041820646595128471}
   - component: {fileID: 8621934090166200953}
   - component: {fileID: 4776147618969797886}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sphere (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2313,6 +2313,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: ee0f4b5749b2bf24592de43c38cd5d29, type: 3}
       propertyPath: m_Name
       value: BonsaiM1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ee0f4b5749b2bf24592de43c38cd5d29, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Amenities/Food/Lvl 2/Prefabs/FoodL2 Variant.prefab
+++ b/Assets/Amenities/Food/Lvl 2/Prefabs/FoodL2 Variant.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5226950108332842876}
   - component: {fileID: 4252288541611090443}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sound
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -264,9 +264,25 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[8]
       value: 
       objectReference: {fileID: 2100000, guid: 0ff8221595376774a87a723d7dbeadef, type: 2}
+    - target: {fileID: -2147642314998828177, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -1359110824882932502, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -733528298368146570, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
       propertyPath: m_Name
       value: FoodL2 Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
       propertyPath: m_TagString
@@ -280,6 +296,14 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: 8fcdbd387d885c14aba27971237cc58b, type: 2}
+    - target: {fileID: 3615287726823673526, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4830418562428712030, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6472065874707415554, guid: 50f58c892c68a464fa379edc8061f711, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -512,6 +536,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: ToonConfettiDirectionalPastel
       objectReference: {fileID: 0}
+    - target: {fileID: 2742492824044505757, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3887977740042797703, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
@@ -519,6 +547,18 @@ PrefabInstance:
     - target: {fileID: 4181871130265796722, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4402713992100065107, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6953117531023919729, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8420125688860540082, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Amenities/Food/Lvl 2/Prefabs/FoodMedium2.prefab
+++ b/Assets/Amenities/Food/Lvl 2/Prefabs/FoodMedium2.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 962948242597525682}
   - component: {fileID: 3988874927519351645}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sound
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -200,6 +200,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: ToonConfettiDirectionalPastel
       objectReference: {fileID: 0}
+    - target: {fileID: 2742492824044505757, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3887977740042797703, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
@@ -207,6 +211,18 @@ PrefabInstance:
     - target: {fileID: 4181871130265796722, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4402713992100065107, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6953117531023919729, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8420125688860540082, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -282,10 +298,18 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: 0.032
       objectReference: {fileID: 0}
+    - target: {fileID: -5494564088225316871, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: -4778805183336687447, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 68728a3a3b69d0d48a10f7e20dd96ad8, type: 2}
+    - target: {fileID: -4680760081622440252, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: -4441123254581353791, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -310,9 +334,17 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: ad4a36bedc9f9f145bcd8587afcd3a85, type: 2}
+    - target: {fileID: 278821990349982122, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
       propertyPath: m_Name
       value: FoodMedium2
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
       propertyPath: m_TagString
@@ -330,6 +362,10 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[2]
       value: 
       objectReference: {fileID: 2100000, guid: 61c481643fe926a448ad1bcf4ea6dd4f, type: 2}
+    - target: {fileID: 6475020241211157112, guid: c1c43ef4fde490d48a918e0f805b9dd6, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:

--- a/Assets/Amenities/Food/Lvl 2/Prefabs/FoodS2 Variant.prefab
+++ b/Assets/Amenities/Food/Lvl 2/Prefabs/FoodS2 Variant.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4301136557068862630}
   - component: {fileID: 7250853842963784044}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sound
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -184,6 +184,10 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 2d0fffdbd7172ca4d806810c0eb01bd8, type: 2}
+    - target: {fileID: -3653803562509026937, guid: 06f6c5ebf2a2efd4fb20ccf2dc090d65, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: -3126676926227174354, guid: 06f6c5ebf2a2efd4fb20ccf2dc090d65, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -196,9 +200,17 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[2]
       value: 
       objectReference: {fileID: 2100000, guid: 61c481643fe926a448ad1bcf4ea6dd4f, type: 2}
+    - target: {fileID: -1695000146548576313, guid: 06f6c5ebf2a2efd4fb20ccf2dc090d65, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 06f6c5ebf2a2efd4fb20ccf2dc090d65, type: 3}
       propertyPath: m_Name
       value: FoodS2 Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 06f6c5ebf2a2efd4fb20ccf2dc090d65, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 06f6c5ebf2a2efd4fb20ccf2dc090d65, type: 3}
       propertyPath: m_TagString
@@ -208,6 +220,10 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 68728a3a3b69d0d48a10f7e20dd96ad8, type: 2}
+    - target: {fileID: 8499504027580254940, guid: 06f6c5ebf2a2efd4fb20ccf2dc090d65, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:
@@ -404,6 +420,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: ToonConfettiDirectionalPastel
       objectReference: {fileID: 0}
+    - target: {fileID: 2742492824044505757, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3887977740042797703, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
@@ -411,6 +431,18 @@ PrefabInstance:
     - target: {fileID: 4181871130265796722, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4402713992100065107, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6953117531023919729, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8420125688860540082, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Amenities/Food/Lvl 3/Prefabs/FoodL3 Variant.prefab
+++ b/Assets/Amenities/Food/Lvl 3/Prefabs/FoodL3 Variant.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3737608227331550689}
   - component: {fileID: 2849780853529326822}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sound
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -200,6 +200,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: ToonConfettiDirectionalPastel
       objectReference: {fileID: 0}
+    - target: {fileID: 2742492824044505757, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3887977740042797703, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
@@ -207,6 +211,18 @@ PrefabInstance:
     - target: {fileID: 4181871130265796722, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4402713992100065107, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6953117531023919729, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8420125688860540082, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -274,6 +290,14 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 42b9857142bb57f4480a20d81338e645, type: 2}
+    - target: {fileID: -3998595984231121370, guid: bb6da5a56abd4e04cb7cd42ab427527d, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -3333021970230017534, guid: bb6da5a56abd4e04cb7cd42ab427527d, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: -1331101779368501877, guid: bb6da5a56abd4e04cb7cd42ab427527d, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -359,8 +383,16 @@ PrefabInstance:
       value: FoodL3 Variant
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: bb6da5a56abd4e04cb7cd42ab427527d, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: bb6da5a56abd4e04cb7cd42ab427527d, type: 3}
       propertyPath: m_TagString
       value: Amenity
+      objectReference: {fileID: 0}
+    - target: {fileID: 2497053522756568025, guid: bb6da5a56abd4e04cb7cd42ab427527d, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 6798596554959794351, guid: bb6da5a56abd4e04cb7cd42ab427527d, type: 3}
       propertyPath: m_Materials.Array.data[0]

--- a/Assets/Amenities/Food/Lvl 3/Prefabs/FoodM3 Variant.prefab
+++ b/Assets/Amenities/Food/Lvl 3/Prefabs/FoodM3 Variant.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6182010629953564051}
   - component: {fileID: 4344186240333123863}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sound
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -180,6 +180,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -5681933298075348338, guid: c2fc7e80d065f0c499b107139940578a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -4899707563168561970, guid: c2fc7e80d065f0c499b107139940578a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: -3374464275404070841, guid: c2fc7e80d065f0c499b107139940578a, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -204,9 +212,17 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[3]
       value: 
       objectReference: {fileID: 2100000, guid: 61c481643fe926a448ad1bcf4ea6dd4f, type: 2}
+    - target: {fileID: -71606461099567394, guid: c2fc7e80d065f0c499b107139940578a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: c2fc7e80d065f0c499b107139940578a, type: 3}
       propertyPath: m_Name
       value: FoodM3 Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: c2fc7e80d065f0c499b107139940578a, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: c2fc7e80d065f0c499b107139940578a, type: 3}
       propertyPath: m_TagString
@@ -411,6 +427,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: ToonConfettiDirectionalPastel
       objectReference: {fileID: 0}
+    - target: {fileID: 2742492824044505757, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3887977740042797703, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
@@ -418,6 +438,18 @@ PrefabInstance:
     - target: {fileID: 4181871130265796722, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4402713992100065107, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6953117531023919729, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8420125688860540082, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Amenities/Food/Lvl 3/Prefabs/FoodS3 Variant.prefab
+++ b/Assets/Amenities/Food/Lvl 3/Prefabs/FoodS3 Variant.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4229477075050609343}
   - component: {fileID: 4806125427702508943}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Sound
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -188,6 +188,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: ToonConfettiDirectionalPastel
       objectReference: {fileID: 0}
+    - target: {fileID: 2742492824044505757, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3887977740042797703, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
@@ -195,6 +199,18 @@ PrefabInstance:
     - target: {fileID: 4181871130265796722, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4402713992100065107, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6953117531023919729, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8420125688860540082, guid: 35bcfdf233b61f64bb101b3c44b76d17, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -258,6 +274,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -6471938927169095599, guid: e1d4d0eef6778e54d972dfa0fa64db68, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: -1628370938255846368, guid: e1d4d0eef6778e54d972dfa0fa64db68, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -274,9 +294,17 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[3]
       value: 
       objectReference: {fileID: 2100000, guid: 61c481643fe926a448ad1bcf4ea6dd4f, type: 2}
+    - target: {fileID: 674030976275500904, guid: e1d4d0eef6778e54d972dfa0fa64db68, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: e1d4d0eef6778e54d972dfa0fa64db68, type: 3}
       propertyPath: m_Name
       value: FoodS3 Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: e1d4d0eef6778e54d972dfa0fa64db68, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: e1d4d0eef6778e54d972dfa0fa64db68, type: 3}
       propertyPath: m_TagString

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -15,6 +15,7 @@ TagManager:
   - Left
   - Right
   - PlotPurchase
+  - Fence
   layers:
   - Default
   - TransparentFX
@@ -22,7 +23,7 @@ TagManager:
   - Grass
   - Water
   - UI
-  - 
+  - Amenity
   - 
   - 
   - 


### PR DESCRIPTION
All food amenities were transferred to the layer "Amenity" so that the particle emitter can ignore the layer for collisions